### PR TITLE
Error during "make" phase, using gcc 11.2, fedora 34

### DIFF
--- a/src/cntd.h
+++ b/src/cntd.h
@@ -497,7 +497,7 @@ typedef struct
 #endif
 } CNTD_t;
 
-CNTD_t *cntd;
+extern CNTD_t *cntd;
 
 // HEADERS
 // arch.c


### PR DESCRIPTION
During the "make" phase I got the following error:

[100%] Linking C shared library libcntd.so
/usr/bin/ld: CMakeFiles/cntd.dir/init.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/eam_slack.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/pm.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/eam.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/report.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/sampling.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/tool.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/timer.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/wrapper_pmpi_c_cpp.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
/usr/bin/ld: CMakeFiles/cntd.dir/wrapper_pmpi_fortran.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: multiple definition of `cntd'; CMakeFiles/cntd.dir/arch.c.o:/home/ftesser/Downloads/countdown/src/cntd.h:500: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/cntd.dir/build.make:258: src/libcntd.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:98: src/CMakeFiles/cntd.dir/all] Error 2
make: *** [Makefile:136: all] Error 2

I am using gcc 11.2, under fedora 34.

The present commit solves the "problem".